### PR TITLE
Add getTagSurface function

### DIFF
--- a/data.js
+++ b/data.js
@@ -2172,6 +2172,16 @@ class Word extends ImmutableArray {
    * @inheritDoc
    */
 
+  getTagSurface() {
+    return this.map(m => ({ tag: m._tag, surface: m.surface}))
+  }
+  /**
+   * tag 와 surface 로 이루어진 Object 로 반환합니다.
+   *
+   * 예) [ { tag: 'NNG', surface: '고양이' }, { tag: 'JX', surface: '는' } ]
+   *
+   * @return {Object} tag 와 surface 로 이루어진 Object
+   */
 
   toString() {
     return `${this.surface} = ${this.singleLineString()}`;


### PR DESCRIPTION
### 이슈를 참조해주세요. (Reference of the issue)
- 없습니다.

### 무엇이 변경되었나요? (Description of the changes)
- data.js 에 있는 `Word` 클래스에 tag 와 surface 를 Object 로 반환하는 함수를 추가하였습니다.
- 예시
```
# Input) 고양이는
# Output) 
[ { tag: 'NNG', surface: '고양이' }, { tag: 'JX', surface: '는' } ]

# Input) 귀엽습니다.
# Output)
[
  { tag: 'VA', surface: '귀엽' },
  { tag: 'EF', surface: '습니다' },
  { tag: 'SF', surface: '.' }
]
```

### 확인자 (Reviewer)
@nearbydelta 
